### PR TITLE
Add pluck method to slave connection methods list

### DIFF
--- a/lib/db_charmer/rails3/active_record/relation/connection_routing.rb
+++ b/lib/db_charmer/rails3/active_record/relation/connection_routing.rb
@@ -4,7 +4,7 @@ module DbCharmer
       module ConnectionRouting
 
         # All the methods that could be querying the database
-        SLAVE_METHODS = [ :calculate, :exists? ]
+        SLAVE_METHODS = [ :calculate, :exists?, :pluck ]
         MASTER_METHODS = [ :delete, :delete_all, :destroy, :destroy_all, :reload, :update, :update_all ]
         ALL_METHODS = SLAVE_METHODS + MASTER_METHODS
 


### PR DESCRIPTION
Under the following circumstances, 

```
class Car < ActiveRecord::Base
  db_magic :slave => :slave01
end
```

Currently, ActiveRecord::Calculations pluck method queries the master node.

```
[3] pry(main)> Car.where(id:1).pluck(:id)
  SQL (0.3ms) [Shard: master] SELECT `cars`.`id` FROM `cars` WHERE `cars`.`id` = 1
=> []
```

After patching, pluck method will query a slave node. 

```
[6] pry(main)> Car.where(id:1).pluck(:id)
  SQL (0.3ms) [slave01] SELECT `cars`.`id` FROM `cars` WHERE `cars`.`id` = 1
=> []
```
